### PR TITLE
Add navigation bar and hero homepage

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import "../globals.css";
 import type { Metadata } from "next";
 import { CartProvider } from "@/lib/cart";
+import Navbar from "@/components/Navbar";
 
 export const metadata: Metadata = { title: "Nature's Way Soil" };
 
@@ -10,7 +11,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
-        <CartProvider>{children}</CartProvider>
+        <CartProvider>
+          <Navbar />
+          {children}
+        </CartProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,20 +1,24 @@
-"use client"
+"use client";
 
-import { Button } from "@/components/ui/Button"
+import Link from "next/link";
+import HeroSection from "@/components/HeroSection";
+import { Button } from "@/components/ui/Button";
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-background p-4 text-foreground">
-      <h1 className="text-4xl font-bold mb-6">Welcome to Nature&apos;s Way Soil</h1>
-      <p className="text-lg mb-6 text-muted-foreground">
-        This is a Next.js + Tailwind starter page.
-      </p>
-
-      <div className="flex gap-4">
-        <Button>Default Button</Button>
-        <Button>Destructive</Button>
-        <Button>Large Outline</Button>
-      </div>
+    <main className="flex flex-col items-center">
+      <HeroSection />
+      <section className="flex flex-col items-center text-center py-8 px-4 max-w-2xl">
+        <h1 className="text-4xl font-bold mb-4">
+          Welcome to Nature&apos;s Way Soil
+        </h1>
+        <p className="text-lg mb-6 text-muted-foreground">
+          Premium soil and gardening supplies delivered to your door.
+        </p>
+        <Link href="/products">
+          <Button>Shop Products</Button>
+        </Link>
+      </section>
     </main>
-  )
+  );
 }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { CartButton } from './CartButton';
+import { CartButton } from '@/components/CartButton';
 
 export default function Navbar() {
   return (

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import Link from 'next/link';
+import { CartButton } from './CartButton';
+
+export default function Navbar() {
+  return (
+    <nav className="flex items-center justify-between p-4 bg-background border-b">
+      <Link href="/" className="text-lg font-semibold">Nature&apos;s Way Soil</Link>
+      <div className="flex items-center gap-4">
+        <Link href="/products" className="hover:underline">Products</Link>
+        <CartButton className="border" />
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable navigation bar with product link and cart button
- include Navbar in root layout so it appears on all pages
- design hero-based home page with call to shop products

## Testing
- `npm run lint`
- `npm run build` (fails: STRIPE_SECRET_KEY is not set)


------
https://chatgpt.com/codex/tasks/task_e_68af756eb01483339f7a7d2fed706bbd