### PR TITLE
Handle missing Stripe keys and fix button classname

### DIFF
--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -16,6 +16,10 @@ export async function POST(req: NextRequest) {
       process.env.NEXT_PUBLIC_SITE_URL ||
       `${req.nextUrl.protocol}//${req.headers.get('host')}`;
 
+    if (!stripe) {
+      return NextResponse.json({ error: 'Stripe not configured' }, { status: 500 })
+    }
+
     const session = await stripe.checkout.sessions.create({
       mode: 'payment',
       line_items: items.map((i: any) => ({
@@ -28,9 +32,9 @@ export async function POST(req: NextRequest) {
       })),
       success_url: `${origin}/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${origin}/cancel`
-    });
+    })
 
-    return NextResponse.json({ url: session.url }, { status: 200 });
+    return NextResponse.json({ url: session.url }, { status: 200 })
   } catch (err: any) {
     return NextResponse.json({ error: err.message || 'Server error' }, { status: 500 });
   }

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -7,8 +7,8 @@ export function Button(props: React.ButtonHTMLAttributes<HTMLButtonElement>) {
     <button
       {...props}
       className={
-        "inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium bg-black text-white hover:bg-black/90 " +
-        (props.className ?? "")
+        "inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium bg-black text-white hover:bg-black/90" +
+        (props.className ? " " + props.className : "")
       }
     />
   )

--- a/context/CartContext.tsx
+++ b/context/CartContext.tsx
@@ -4,7 +4,7 @@ import React, { createContext, useState, useContext } from 'react';
 import { Product } from '../data/products';
 import { loadStripe } from '@stripe/stripe-js';
 
-const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || "");
+const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || null);
 
 export const CartContext = createContext<any>(null);
 

--- a/context/CartContext.tsx
+++ b/context/CartContext.tsx
@@ -4,7 +4,7 @@ import React, { createContext, useState, useContext } from 'react';
 import { Product } from '../data/products';
 import { loadStripe } from '@stripe/stripe-js';
 
-const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!);
+const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || "");
 
 export const CartContext = createContext<any>(null);
 
@@ -23,6 +23,7 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
 
   const handleCheckout = async () => {
     const stripe = await stripePromise;
+    if (!stripe) return;
     const res = await fetch('/api/checkout', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -36,7 +37,7 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
       }),
     });
     const session = await res.json();
-    await stripe?.redirectToCheckout({ sessionId: session.id });
+    await stripe.redirectToCheckout({ sessionId: session.id });
   };
 
   return (

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -5,6 +5,6 @@ if (!process.env.STRIPE_SECRET_KEY) {
   console.warn("STRIPE_SECRET_KEY is not set")
 }
 
-export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? "sk_test_placeholder", {
-  apiVersion: "2024-06-20"
-})
+export const stripe = process.env.STRIPE_SECRET_KEY
+  ? new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: "2024-06-20" })
+  : null


### PR DESCRIPTION
## Summary
- ensure Stripe SDK loads only when `STRIPE_SECRET_KEY` is present and report configuration errors in checkout API
- guard cart checkout against missing publishable key
- fix `Button` component classname concatenation so custom classes apply correctly

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c37f0bd1248333bd85354cd1979f21